### PR TITLE
feat: 채팅 목록 페이지 기능 구현 완료

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { SelectState } from './redux/config/configStore';
 import ChatAlarm from './layout/ChatAlarm';
 import ChatRoomPage from './pages/ChatRoomPage';
 import FollowingPage from './pages/FollowingPage';
+import ChatRoomListPage from './pages/ChatRoomListPage';
 
 function App() {
   const [token] = useState(localStorage.getItem('accessToken'));
@@ -27,17 +28,20 @@ function App() {
     <>
       {isLoggedIn && <ChatAlarm />}
       <Routes>
-        <Route path='/' element={<PageLayout />}>
+        <Route path='/' element={<PageLayout headerFooterExist={true} />}>
           <Route path='' element={<MainPage />} />
+          <Route path='musics/:musicId' element={<MusicDetailPage />} />
+          <Route path='users/:userId' element={<UserPage />} />
+          <Route path='following' element={<FollowingPage />} />
+          <Route path='chats' element={<ChatRoomListPage />} />
+        </Route>
+        <Route path='/' element={<PageLayout headerFooterExist={false} />}>
           <Route path='login' element={<LoginPage />} />
           <Route path='signup' element={<SignUpPage />} />
           <Route path='forgetpw' element={<ForgetPwPage />} />
           <Route path='changepw' element={<ChangePwPage />} />
-          <Route path='musics/:musicId' element={<MusicDetailPage />} />
-          <Route path='users/:userId' element={<UserPage />} />
-          <Route path='following' element={<FollowingPage />} />
+          <Route path='chat-room/:roomId' element={<ChatRoomPage />} />
         </Route>
-        <Route path='/chat-room/:roomId' element={<ChatRoomPage />} />
       </Routes>
     </>
   );

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -1,7 +1,15 @@
 import { AxiosResponse } from 'axios';
 import { getWithToken } from './withToken';
+import store from '../redux/config/configStore';
+import ourAxios from './ourAxios';
 
 export const getRoomChatsP = (roomId: string) => async () => {
   const { data }: AxiosResponse = await getWithToken(`/api/chat/${roomId}/chat-list`);
+  return data;
+};
+
+export const getChatRoomList = async () => {
+  const { userId } = store.getState().userInfo;
+  const { data }: AxiosResponse = await ourAxios.get(`/api/chat/${userId}/room-list`);
   return data;
 };

--- a/src/components/chatRoomListPage/ChatRoom.tsx
+++ b/src/components/chatRoomListPage/ChatRoom.tsx
@@ -1,0 +1,26 @@
+import { useNavigate } from 'react-router-dom';
+import { ChatState } from '../../redux/modules/chatList';
+import { ChatRoomInfoContainer } from './styles/chatRoomInfoStyle';
+
+export interface ChatRoomInfo {
+  roomName: string;
+  nickName: string;
+  lastChatMessage: ChatState;
+}
+
+function ChatRoom({ chatRoom }: { chatRoom: ChatRoomInfo }) {
+  const navigate = useNavigate();
+
+  const handleRoomClick = () => {
+    navigate(`/chat-room/${chatRoom.roomName}`);
+  };
+
+  return (
+    <ChatRoomInfoContainer onClick={handleRoomClick}>
+      <div>{chatRoom.nickName}</div>
+      <div>{chatRoom.lastChatMessage.message}</div>
+    </ChatRoomInfoContainer>
+  );
+}
+
+export default ChatRoom;

--- a/src/components/chatRoomListPage/styles/chatRoomInfoStyle.ts
+++ b/src/components/chatRoomListPage/styles/chatRoomInfoStyle.ts
@@ -1,0 +1,6 @@
+import { styled } from 'styled-components';
+
+export const ChatRoomInfoContainer = styled.div`
+  height: 56px;
+  padding: 5px;
+`;

--- a/src/components/chatRoomPage/ChatSender.tsx
+++ b/src/components/chatRoomPage/ChatSender.tsx
@@ -18,6 +18,7 @@ function ChatSender({ chats, setChats, opId }: ChatSenderProps) {
 
   const { send } = useStomp({ brokerURL: process.env.REACT_APP_BROKER_URL });
   const { userId, nickname } = useSelector((state: SelectState) => state.userInfo);
+
   const handleSendClick = () => {
     const myChat: ChatState = {
       nickname,
@@ -27,6 +28,7 @@ function ChatSender({ chats, setChats, opId }: ChatSenderProps) {
     };
     setChats([...chats, myChat]);
     send(`/pub/user/${opId}`, myChat, {});
+    setMsg('');
   };
   return (
     <div>

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -10,7 +10,7 @@ function Footer() {
 
   return (
     <FooterContainer>
-      <ButtonContainer>
+      <ButtonContainer onClick={() => navigate('/chats')}>
         <IconButton src={MessageButtonIcon} alt='MessageButton Icon' />
       </ButtonContainer>
       <ButtonContainer onClick={() => navigate('')}>

--- a/src/layout/PageLayout.tsx
+++ b/src/layout/PageLayout.tsx
@@ -3,14 +3,20 @@ import Header from './Header';
 import Footer from './Footer';
 import styled from 'styled-components';
 
-function PageLayout() {
+function PageLayout({ headerFooterExist }: { headerFooterExist: boolean }) {
   return (
     <>
       <PageContainer>
         <AllPage>
-          <Header />
-          <Outlet />
-          <Footer />
+          {headerFooterExist ? (
+            <>
+              <Header />
+              <Outlet />
+              <Footer />
+            </>
+          ) : (
+            <Outlet />
+          )}
         </AllPage>
       </PageContainer>
     </>

--- a/src/pages/ChatRoomListPage.tsx
+++ b/src/pages/ChatRoomListPage.tsx
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { getChatRoomList } from '../api/chat';
+import { useEffect, useState } from 'react';
+import ChatRoom, { ChatRoomInfo } from '../components/chatRoomListPage/ChatRoom';
+
+function ChatRoomListPage() {
+  const [chatRooms, setChatRooms] = useState<ChatRoomInfo[]>([]);
+  const { data, isSuccess } = useQuery(['ChatRoomList'], getChatRoomList);
+
+  useEffect(() => {
+    if (isSuccess) {
+      setChatRooms(data);
+    }
+  }, [isSuccess]);
+
+  console.log(chatRooms);
+  return (
+    <div>
+      {chatRooms.map((chatRoom, index) => (
+        <ChatRoom chatRoom={chatRoom} key={index} />
+      ))}
+    </div>
+  );
+}
+
+export default ChatRoomListPage;


### PR DESCRIPTION
채팅 목록 페이지 기능을 구현하였습니다. 현재 상대방의 닉네임정보가 응답데이터에 없어 메세지만 보입니다. 메세지를 클릭하면 해당 사용자와의 채팅방으로 이동합니다.